### PR TITLE
allow fully-qualified kelp module names

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -56,10 +56,14 @@ sub new {
 sub load_module {
     my ( $self, $name, %args ) = @_;
 
+    # A module name with a leading + indicates it's already fully
+    # qualified (i.e., it does not need the Kelp::Module:: prefix).
+    my $prefix = $name =~ s/^\+// ? undef : 'Kelp::Module';
+
     # Make sure the module was not already loaded
     return if $self->loaded_modules->{$name};
 
-    my $class = Plack::Util::load_class( $name, 'Kelp::Module' );
+    my $class = Plack::Util::load_class( $name, $prefix );
     my $module = $self->loaded_modules->{$name} = $class->new( app => $self );
 
     # When loading the Config module itself, we don't have

--- a/t/lib/MyApp/Module/Null.pm
+++ b/t/lib/MyApp/Module/Null.pm
@@ -1,0 +1,9 @@
+package MyApp::Module::Null;
+use Kelp::Base 'Kelp::Module';
+
+sub build {
+    my ( $self, %args ) = @_;
+    $self->register( plus => sub { $_[1] + $args{number} } );
+}
+
+1;

--- a/t/module_load.t
+++ b/t/module_load.t
@@ -2,6 +2,7 @@ BEGIN {
     $ENV{KELP_REDEFINE} = 1;
 }
 
+use lib 't/lib';
 use Kelp::Base -strict;
 use Kelp;
 use Test::More;
@@ -31,6 +32,15 @@ $cpp->config_hash->{modules_init}->{Null} = {
 };
 $cpp->load_module( 'Null', number => 5 );
 is $cpp->plus(5), 10;
+
+# Fully qualified module name
+my $dpp = Kelp->new;
+$dpp->config_hash->{modules_init}->{'MyApp::Module::Null'} = {
+    number => 4 
+};
+$dpp->load_module( '+MyApp::Module::Null' );
+is $dpp->plus(5), 9;
+
 
 done_testing;
 


### PR DESCRIPTION
Allows Kelp modules to be specified like +MyApp::Module,  in which case Kelp::Module is not prefixed.
