### PR TITLE
Added docs to method redirect_to

### DIFF
--- a/lib/Kelp/Response.pm
+++ b/lib/Kelp/Response.pm
@@ -392,6 +392,17 @@ Designing your own 500 page is also possible. All you need to do is add file 500
 views/error. Keep in mind that it will only show in C<deployment>. In any other mode,
 this method will display the optional error, or the stock error message.
 
+=head2 redirect_to
+
+Redirects the client to a named route or to a given url. In case the route is passed by
+name, a hash reference with the needed arguments can be passed after the route's name.
+As a third optional argument, you can enter the desired response code:
+
+ $self->redirect_to( '/example' );
+ $self->redirect_to( 'catalogue' );
+ $self->redirect_to( 'catalogue', { id => 243 });
+ $self->redirect_to( 'other', {}, 303 );
+
 =head2 template
 
 This method renders a template. The template should be previously configured by

--- a/t/response_redirect.t
+++ b/t/response_redirect.t
@@ -1,0 +1,32 @@
+use Kelp::Base -strict;
+
+use Kelp;
+use Kelp::Test;
+use HTTP::Request::Common;
+use Test::More tests => 8;
+
+my $app = Kelp->new( mode => 'test' );
+my $t = Kelp::Test->new( app => $app );
+
+$app->add_route( '/test' => sub { shift->res->redirect_to('/example') });
+$t->request( GET '/test' )
+    ->header_is('Location', '/example')
+    ->code_is(302);
+
+$app->add_route( '/catalogue/:id' => { to => 'test_catalogue', name => 'catalogue', defaults => { id => 'all' }});
+$app->add_route( '/test2' => sub { shift->res->redirect_to('catalogue') });
+$t->request( GET '/test2' )
+    ->header_is('Location', '/catalogue/all')
+    ->code_is(302);
+
+$app->add_route( '/test3' => sub { shift->res->redirect_to('catalogue', {id => 243}) });
+$t->request( GET '/test3' )
+    ->header_is('Location', '/catalogue/243')
+    ->code_is(302);
+
+$app->add_route( '/test4' => sub { shift->res->redirect_to('catalogue', {}, 403) });
+$t->request( GET '/test4' )
+    ->header_is('Location', '/catalogue/all')
+    ->code_is(403);
+
+done_testing;


### PR DESCRIPTION
Hi!
First of all, thank you for your nice framework. I really like it.

This pull request adds docs for the method 'redirect_to' in Kelp::Response, which are missing. I also added a test file to make sure that the docs I wrote are correct.

Best regards,

Julio
