### PR TITLE
do not append default template extension if ext() is undefined or blank

### DIFF
--- a/lib/Kelp/Module/Template.pm
+++ b/lib/Kelp/Module/Template.pm
@@ -34,9 +34,11 @@ sub render {
 sub _rename {
     my ( $self, $name ) = @_;
     return unless $name;
-    return !ref($name) && $name !~ /\.(.+)$/
-      ? $name . '.' . $self->ext
-      : $name;
+
+    return $name if ref($name) || $name =~ /\.(.+)$/;
+
+    my $ext = $self->ext;
+    return (defined $ext && length $ext) ? "$name.$ext" : $name;
 }
 
 1;

--- a/t/module_template.t
+++ b/t/module_template.t
@@ -18,5 +18,17 @@ isa_ok $m, 'Kelp::Module::Template';
 can_ok $app, $_ for qw/template/;
 is $app->template( \"[% a %] ☃", { a => 4 } ), '4 ☃', "Process";
 
+
+# Test automatic appending of default extension to template names
+my $ext = 'foo';
+is $m->ext($ext), $ext, 'set default template ext';
+is $m->ext, $ext, 'get default template ext';
+is $m->_rename('home'), "home.$ext", 'if no extension, default appended';
+is $m->_rename('home.tt'), 'home.tt', 'if extension, default not appended';
+$m->ext('');
+is $m->_rename('home'), 'home', 'if no default defined, no change';
+$m->ext('tt');
+
+
 done_testing;
 


### PR DESCRIPTION
I noticed BTW that attr() doesn't allow setting the value of undef. Is that intentional?

Kelp::Base has:

``` Perl
if ( defined $_[1] && !$readonly ) {
            $_[0]->{$name} = $_[1];
}
```

Can we change that to if (@_ > 1 && !$readonly) ?
