### PR TITLE
don't double encode JSON repsonse

### DIFF
--- a/lib/Kelp/Response.pm
+++ b/lib/Kelp/Response.pm
@@ -82,10 +82,14 @@ sub render {
     if ( $self->content_type eq 'application/json' ) {
         confess "No JSON decoder" unless $self->app->can('json');
         confess "Data must be a reference" unless ref($body);
-        $body = $self->app->json->encode($body);
+        my $json = $self->app->json;
+        $body = $json->encode($body);
+        $body = encode('UTF-8', $body) unless $json->property('utf8');
+        $self->body( $body );
+    } else {
+        $self->body( encode( $self->app->charset, $body ) );
     }
 
-    $self->body( encode( $self->app->charset, $body ) );
     $self->rendered(1);
     return $self;
 }


### PR DESCRIPTION
by default json encoder does utf8 -> bytes conversion and this thing is optional, so check property and decide what to do.

Try $app->res->json->render({res => "\x{442}"}); and it result in double encoded string. This happens as $app->json module has "utf8" property enabled by default, so $app->json->encode( ... ) produces octets and then later code calls "encode()" on octets.

\x{442} is small Russian T
