### PR TITLE
I think it should be as ...

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -491,7 +491,7 @@ units for your web app.
 This is the L<PSGI> file, of the app, which you will deploy. In it's most basic
 form it should look like this:
 
-    use lib '../lib';
+    use lib './lib';
     use MyApp;
 
     my $app = MyApp->new;


### PR DESCRIPTION
Hi,

In documentation app.psgi file to be run in directory structure where lib located as ./lib relative from app.psgi
But in doc you use ../lib
I think it should be as "use lib 'lib'" or "use lib './lib'"
