### PR TITLE
Add POD-hint: REMOTE_ADDR is not set when using proxy via filesocket

### DIFF
--- a/lib/Kelp/Request.pm
+++ b/lib/Kelp/Request.pm
@@ -150,10 +150,12 @@ to use L<Plack::Middleware::ReverseProxy>.
     # app.psgi
 
     builder {
-        enable_if { $_[0]->{REMOTE_ADDR} =~ /127\.0\.0\.1/ }
+        enable_if { ! $_[0]->{REMOTE_ADDR} || $_[0]->{REMOTE_ADDR} =~ /127\.0\.0\.1/ }
         "Plack::Middleware::ReverseProxy";
         $app->run;
     };
+
+(REMOTE_ADDR is not set at all when using the proxy via filesocket).
 
 =head2 session
 


### PR DESCRIPTION
I had trouble today when forwarding requests from nginx to Kelp via filesocket: REMOTE_ADDR is not set at all in this case. So the suggested way in the POD to enable Plack::Middleware::ReverseProxy was not working.

Now the existence of REMOTE_ADDR is checked first.
