### PR TITLE
Forse error 500 stringification

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -209,7 +209,9 @@ sub psgi {
         $self->logger( 'critical', $message ) if $self->can('logger');
 
         # Render 500
-        $self->res->render_500($message);
+        # force stringificaion to avoid exception class JSONization,
+        # which in case of fail will become null, but that is useles
+        $self->res->render_500("$message");
         $self->finalize;
     };
 }


### PR DESCRIPTION
Hi,

Without the patch, there would be the following strange error output for the application:

``` perl
use Kelp::Less;

module 'JSON', pretty => 1;

package t::SomeException {
    sub new {
        return bless {} => shift;
    }
}

get '/' => sub {
    die(t::SomeException->new);
};

run;
```

the test:

``` perl
use strict;
use warnings;

use Test::More;
use Kelp::Test;
use HTTP::Request::Common;

my $t = Kelp::Test->new( psgi => 'app.psgi' );
$t->request( GET '/' )
    ->code_is(200);

done_testing;
```

and the output:

```
LACK_ENV=test perl 2.t                                  
# GET /
not ok 1 - Response code is 200
#   Failed test 'Response code is 200'
#   at 2.t line 9.
#          got: '500'
#     expected: '200'
not ok 2 - null
# 
#   Failed test 'null
# '
#   at 2.t line 9.
1..2
# Looks like you failed 2 tests of 2.
```

It is rather hard to detect what is going wrong. The flow is the following: it invokes Response:: **render_500** method, then **render**, and if it detects that the **$message** is a reference, that it JSONizes it to null. That is wrong, because the exceptions aren't JSONizable in general.

With the applied patch it outputs

```
# GET /
not ok 1 - Response code is 200
#   Failed test 'Response code is 200'
#   at 2.t line 9.
#          got: '500'
#     expected: '200'
not ok 2 - t::SomeException=HASH(0x2209e70)
#   Failed test 't::SomeException=HASH(0x2209e70)'
#   at 2.t line 9.
1..2
# Looks like you failed 2 tests of 2.
```

That's a bit more useful, isn't it? In real-world it is good to expect that exception supports stringification, than instead of null, or just class name, we get human-readable exception. E.g. for DBIx::Class::

```
        #   Failed test 'Response code is 200'
        #   at t/api/05-content.t line 41.
        #          got: '500'
        #     expected: '200'
        not ok 2 - DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::SQLite::st execute failed: NOT NULL constraint failed: lesson.modified [for Statement "INSERT INTO "lesson" ( "content", "free", "level", "name", "order_in_topic", "teacher_id", "topic_id") VALUES ( ?, ?, ?, ?, ?, ?, ? )"] at lib/Hethurin/Backend/Controller/Contents.pm line 67
        # 
        #   Failed test 'DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::SQLite::st execute failed: NOT NULL constraint failed: lesson.modified [for Statement "INSERT INTO "lesson" ( "content", "free", "level", "name", "order_in_topic", "teacher_id", "topic_id") VALUES ( ?, ?, ?, ?, ?, ?, ? )"] at lib/Hethurin/Backend/Controller/Contents.pm line 67
```
