### PR TITLE
More documentation for the stash of Kelp::Request

### DIFF
--- a/lib/Kelp/Request.pm
+++ b/lib/Kelp/Request.pm
@@ -101,7 +101,7 @@ A reference to the Kelp application.
 
 =head2 stash
 
-Returns a hashref, which represents stash the current the request
+Returns a hashref, which represents the stash of the current the request
 
 An all use, utility hash to use to pass information between routes. The stash
 is a concept originally conceived by the developers of L<Catalyst>. It's a hash


### PR DESCRIPTION
Hi!

There is "see Kelp::Request/stash" in Kelp.pm, but it is under-documented a little bit. I tried to fix that.
