### PR TITLE
Add example how to render content from file handle

### DIFF
--- a/lib/Kelp/Response.pm
+++ b/lib/Kelp/Response.pm
@@ -361,7 +361,7 @@ before that.
         my $content = File::Slurp::read_file("$name.jpg");
         res->set_content_type('image/jpeg')->render_binary( $content );
 
-        # the same, but probably more effective way (PSGI-server dependend)
+        # the same, but probably more effective way (PSGI-server dependent)
         open( my $handle, "<:raw", "$name.png" )
             or die("cannot open $name: $!");
         res->set_content_type('image/png')->render_binary( $handle );


### PR DESCRIPTION
Hi,

PSGI allows transfer file handle as body content (see https://metacpan.org/pod/distribution/PSGI/PSGI.pod#Body ), which could be more effective than

a. Slurp the whole file content into memory and then send it as response
b. Using sendfile(2) by server.
