### PR TITLE
Inheritable routes

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -598,10 +598,10 @@ C<$self-E<gt>routes>:
 
 =head3 Destinations
 
-You can direct HTTP paths to subroutines in your classes or, you can use inline
-code.
+You can direct HTTP paths to subroutines or methods of your classes, or you can
+use inline code.
 
-    $r->add( "/home", "home" );  # goes to sub home
+    $r->add( "/home", "home" );  # goes to sub home or to $app->home
     $r->add( "/legal", "Legal::view" ); # goes to MyApp::Legal::view
     $r->add( "/about", sub { "Content for about" }); # inline
 

--- a/lib/Kelp/Routes.pm
+++ b/lib/Kelp/Routes.pm
@@ -534,7 +534,7 @@ Adds a new route definition to the routes array.
 C<$path> can be a path string, e.g. C<'/user/view'> or an ARRAY containing a
 method and a path, e.g. C<[ PUT =E<gt> '/item' ]>.
 
-The route destination is very flexible. It can be one of these three things:
+The route destination is very flexible. It can be one of these four things:
 
 =over
 
@@ -545,6 +545,16 @@ to replace C<::> is also allowed, in which case the name will get converted.
 C<"users#item"> becomes C<"Users::item">.
 
     $r->add( '/home' => 'user#home' );
+
+=cut
+
+=item
+
+A string name of a method. Instead of the name of a subroutine in the
+current package, or of a fully qualified subroutine, you can use the
+name of a method. The method can be inherited from a base class.
+
+    $r->add( '/home' => 'some_inherited_method' );
 
 =cut
 

--- a/lib/Kelp/Routes.pm
+++ b/lib/Kelp/Routes.pm
@@ -184,12 +184,18 @@ sub dispatch {
     unless ( ref $to ) {
 
         # Check if the destination function exists
-        unless ( exists &$to ) {
+        if ( exists &$to ) {
+            # Move to reference
+            $to = \&{$to};
+        }
+        elsif ($app->can($to)) {
+            # $to is an inherited method
+            $to = $app->can($to);
+        }
+        else {
             die sprintf( 'Route not found %s for %s', $to, $req->path );
         }
 
-        # Move to reference
-        $to = \&{$to};
     }
 
     return $to->( $app, @{ $route->param } );

--- a/t/lib/MyApp3.pm
+++ b/t/lib/MyApp3.pm
@@ -1,0 +1,17 @@
+package MyApp3;
+use parent 'Kelp';
+use strict;
+use warnings;
+
+# This route will be inherited by subclasses
+sub greet {
+    my ($self, $name) = @_;
+    return "Bonjour, $name";
+}
+
+sub goodbye {
+    my ($self, $name) = @_;
+    return "Au revoir, $name";
+}
+
+1;

--- a/t/lib/MyApp3/Subclass.pm
+++ b/t/lib/MyApp3/Subclass.pm
@@ -1,0 +1,19 @@
+package MyApp3::Subclass;
+use parent 'MyApp3';
+use strict;
+use warnings;
+
+sub build {
+    my $self = shift;
+    my $r    = $self->routes;
+    $r->add( "/test",        sub { "OK" } );
+    $r->add( "/greet/:name", 'greet'      );
+    $r->add( "/bye/:name",   'adieu'      );
+}
+
+sub adieu {
+    my ($self, $name) = @_;
+    return $self->goodbye($name);
+}
+
+1;

--- a/t/routes_inherited.t
+++ b/t/routes_inherited.t
@@ -1,0 +1,19 @@
+use lib 't/lib';
+use MyApp3::Subclass;
+use Kelp::Test;
+use HTTP::Request::Common;
+use Test::More tests => 4;
+use Kelp::Base -strict;
+
+my $app = MyApp3::Subclass->new( mode => 'test' );
+my $t = Kelp::Test->new( app => $app );
+
+$t->request( GET '/greet/jack' )
+  ->code_is(200)
+  ->content_is("Bonjour, jack");
+
+$t->request( GET '/bye/jack' )
+  ->code_is(200)
+  ->content_is("Au revoir, jack");
+
+done_testing();


### PR DESCRIPTION
Hi Stefan,

While I know that the current model is to split routes to other classes (even without an inheritance link), the ability to inherit routes would allow for splitting common routes to the parent and then having multiple subclasses that implement further functionalities. Different subclasses could be wrapped in different psgi applications.
Well, this pull requests does that. No existing tests were harmed by the three or four extra lines in Kelp::Routes, and I added a couple of tests to make sure that methods are indeed inherited.
Thanks again for your time and dedication!