### PR TITLE
building out request_obj and response_obj as generally resolve #39

### DIFF
--- a/t/custom_req_resp.t
+++ b/t/custom_req_resp.t
@@ -1,0 +1,12 @@
+use lib 't/lib';
+use MyApp;
+use Test::More;
+
+ok my $app = MyApp->new( request_obj  => 'MyApp::Request',
+                         reqspose_obj => 'MyApp::Response',
+                       ), q{can build object};
+
+isa_ok $app->build_request({}) , 'MyApp::Request' , q{custom request object};
+isa_ok $app->build_response, 'MyApp::Response', q{custom response object};
+
+done_testing;

--- a/t/lib/MyApp/Request.pm
+++ b/t/lib/MyApp/Request.pm
@@ -1,0 +1,6 @@
+package MyApp::Request;
+use parent 'Kelp::Request';
+
+# here just for testing
+
+1;


### PR DESCRIPTION
Currently Kelp encourage's customers to overwrite methods just to change the class that is used in build_request and build_response. It seems that this would be a great use of an attribute that can be leveraged in this case.

Sigh, I forgot that issues and PR's are now interchangeable. Sorry for the issue spam.