### PR TITLE
Fix undef warning

### DIFF
--- a/bench_all_branches
+++ b/bench_all_branches
@@ -9,7 +9,7 @@ my ($count) = $ARGV[0] // 100;
 my $this_br; # to allow to have git return to the current co branch
 sub mk_test {
     my $br = shift;
-    return sub{ qx{git checkout -q $br && prove -qql} }
+    return sub{ qx{git checkout -q $br && prove -Ql} }
 }
 my %test_set = map{ chomp;                              # drop the newline
                     ($this_br) = $1 if m/^[*]\s+(.*)$/; # capture the branch that we are currently on

--- a/bin-test/bench_all_branches
+++ b/bin-test/bench_all_branches
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Benchmark qw(:all) ;
+
+die qx{perldoc $0} if grep{m/-h/} @ARGV;
+
+my ($count) = $ARGV[0] // 100;
+my $this_br; # to allow to have git return to the current co branch
+sub mk_test {
+    my $br = shift;
+    return sub{ qx{git checkout -q $br && prove -qql} }
+}
+my %test_set = map{ chomp;                              # drop the newline
+                    ($this_br) = $1 if m/^[*]\s+(.*)$/; # capture the branch that we are currently on
+                    s/^.*\s+//;                         # clean up the branches to only be the branch name
+                    $_ => mk_test($_);                  # build our test
+                  } qx{git branch};
+
+cmpthese($count, \%test_set);
+
+qx{git checkout -q $this_br}; # got back to the branch you were on
+
+
+__END__
+=head1 USEAGE
+
+  bench_all_branches -h 
+  bench_all_branches [test run count]
+
+If -h is found in @ARGV then you will see this help text
+
+The default value for [test run count] is 100 if not specified.
+
+Will checkout all branches and then run prove [test run count] times as a way to quickly test how slow your change will likely be.
+
+When done it will return to the branch you were on.
+
+
+

--- a/lib/Kelp/Routes.pm
+++ b/lib/Kelp/Routes.pm
@@ -68,7 +68,7 @@ sub _parse_route {
 
     # Format destination
     if ( !ref $val->{to} ) {
-        my $sigil = $val->{to} =~ s/^(\+)// ? $1 : undef;
+        my $sigil = defined $val->{to} && $val->{to} =~ s/^(\+)// ? $1 : undef;
         $val->{to} = _camelize( $val->{to}, $sigil ? undef : $self->base );
 
         # Load the class, if there is one and it is not 'main'


### PR DESCRIPTION
During my testing with prove I kept seeing: 

```
Use of uninitialized value in substitution (s///) at /home/benh/git/kelp/lib/Kelp/Routes.pm line 71.
```

This fixes that, all tests still pass, though not sure why ->{to} would ever be undef but apparently it is at some point in the test suite.