### PR TITLE
Bridges and not_existing_route

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -208,11 +208,18 @@ sub psgi {
             }
         }
 
-        # If nothing got rendered, die with error
+        # If nothing got rendered
         if ( !$self->res->rendered ) {
-            die $match->[-1]->to
+            # render 404 if only briges matched
+            if ( $match->[-1]->bridge ) {
+                $res->render_404;
+            }
+            # or die with error
+            else {
+              die $match->[-1]->to
               . " did not render for method "
               . $req->method;
+            }
         }
 
         $self->finalize;

--- a/t/run_bridge.t
+++ b/t/run_bridge.t
@@ -19,6 +19,7 @@ $app->add_route(
 $t->request( GET '/bridge' )->code_is(401);
 $t->request( GET '/bridge/route' )->code_is(401);
 $t->request( GET '/bridge/route?code=404' )->code_is(404);
+$t->request( GET '/bridge/not_existing_route?ok=1' )->code_is(404);
 
 $t->request( GET '/bridge/route?ok=1' )
   ->code_is(200)


### PR DESCRIPTION
Hello Stefan,
If we create application where user passes auth bridge and then tries to get some not existing data user expects to see 404 not 500 error. Bridges designed to collect or verify data so we do expect render data from bridge only if we got verifying error. 