### PR TITLE
Moar exceptions

### DIFF
--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -231,7 +231,7 @@ sub psgi {
         $self->logger( 'critical', $message ) if $self->can('logger');
 
         # Render 500
-        $self->res->render_error(500, $message);
+        $self->res->render_error(500, $_);
         $self->finalize;
     };
 }

--- a/lib/Kelp.pm
+++ b/lib/Kelp.pm
@@ -231,7 +231,7 @@ sub psgi {
         $self->logger( 'critical', $message ) if $self->can('logger');
 
         # Render 500
-        $self->res->render_error(500, $_);
+        $self->res->render_500($_);
         $self->finalize;
     };
 }

--- a/lib/Kelp/Response.pm
+++ b/lib/Kelp/Response.pm
@@ -115,8 +115,10 @@ sub render_error {
     my ( $self, $code, $error ) = @_;
 
     $code  //= 500;
-    $error = "Internal Server Error"
-        if !defined $error || Scalar::Util::blessed $error;
+    if (($code == 500 && $self->app->mode eq 'deployment')
+    ||  !defined $error) {
+        $error = "Internal Server Error"
+    }
 
     $self->set_code($code);
 

--- a/lib/Kelp/Response.pm
+++ b/lib/Kelp/Response.pm
@@ -115,10 +115,7 @@ sub render_error {
     my ( $self, $code, $error ) = @_;
 
     $code  //= 500;
-    if (($code == 500 && $self->app->mode eq 'deployment')
-    ||  !defined $error) {
-        $error = "Internal Server Error"
-    }
+    $error //= "Internal Server Error";
 
     $self->set_code($code);
 
@@ -145,12 +142,17 @@ sub render_404 {
 }
 
 sub render_500 {
-    my ( $self, $message ) = @_;
+    my ( $self, $error ) = @_;
 
-    if ( $self->app->mode ne 'deployment' && $message ) {
-        return $self->set_code(500)->render($message);
+    if ( $self->app->mode eq 'deployment') { # || !defined $error) {
+        return $self->render_error;
     }
-
+    
+    if ( defined $error ) {
+        $error .= '' if Scalar::Util::blessed $error;
+        return $self->set_code(500)->render($error);
+    }
+    
     return $self->render_error;
 }
 

--- a/lib/Kelp/Response.pm
+++ b/lib/Kelp/Response.pm
@@ -144,16 +144,14 @@ sub render_404 {
 sub render_500 {
     my ( $self, $error ) = @_;
 
-    if ( $self->app->mode eq 'deployment') { # || !defined $error) {
+    if ( !defined $error || $self->app->mode eq 'deployment' ) {
         return $self->render_error;
     }
+
+    # if render_500 gets blessed object as error stringify it
+    $error = ref $error if Scalar::Util::blessed $error;
     
-    if ( defined $error ) {
-        $error .= '' if Scalar::Util::blessed $error;
-        return $self->set_code(500)->render($error);
-    }
-    
-    return $self->render_error;
+    return $self->set_code(500)->render($error);
 }
 
 sub render_401 {

--- a/t/conf/deployment_no_templates/config.pl
+++ b/t/conf/deployment_no_templates/config.pl
@@ -1,0 +1,7 @@
+{
+    modules_init => {
+        Template => {
+            paths => [] # No error templates
+        }
+    }
+}

--- a/t/conf/stack_trace_enabled/test.pl
+++ b/t/conf/stack_trace_enabled/test.pl
@@ -1,0 +1,15 @@
+{
+    modules_init => {
+        Template => {
+            paths => [] # No error templates
+        }
+    },
+    middleware      => ['StackTrace'],
+    middleware_init => {
+        StackTrace => {
+            force => 1
+        }
+    }
+};
+
+

--- a/t/response_error.t
+++ b/t/response_error.t
@@ -39,12 +39,12 @@ BEGIN {
     $r->add("/exception_text", sub { die "Text exception"; });
     $t->request( GET '/exception_text' )
       ->code_is(500)
-      ->content_like(qr/Five Hundred/);
+      ->content_like(qr/Text exception/);
 
     $r->add("/exception_obj", sub { die bless {}, 'Exception'; });
     $t->request( GET '/exception_obj' )
       ->code_is(500)
-      ->content_like(qr/Five Hundred/);
+      ->content_like(qr/Exception=HASH/);
 }
 
 # No error templates
@@ -82,12 +82,12 @@ BEGIN {
     $r->add("/exception_text", sub { die "Text exception"; });
     $t->request( GET '/exception_text' )
       ->code_is(500)
-      ->content_like(qr/500 - Text exception/);
+      ->content_like(qr/Text exception/);
     
     $r->add("/exception_obj", sub { die bless {}, 'Exception'; });
     $t->request( GET '/exception_obj' )
       ->code_is(500)
-      ->content_like(qr/500 - Exception=HASH/);
+      ->content_like(qr/Exception=HASH/);
 }
 
 # Deployment
@@ -150,8 +150,9 @@ BEGIN {
       ->content_unlike(qr/500 - Internal Server Error/);
 }
 
-
 # Deployment no error templates
+# Any unknown(500) error in deployment mode with out templates
+# must show stock "Internal Server Error" message
 {
     $ENV{KELP_CONFIG_DIR} = "$Bin/conf/deployment_no_templates";
     my $app = Kelp->new( mode => 'deployment' );
@@ -181,6 +182,5 @@ BEGIN {
       ->code_is(500)
       ->content_like(qr/500 - Internal Server Error/);
 }
-
 
 done_testing;

--- a/t/response_error.t
+++ b/t/response_error.t
@@ -44,7 +44,7 @@ BEGIN {
     $r->add("/exception_obj", sub { die bless {}, 'Exception'; });
     $t->request( GET '/exception_obj' )
       ->code_is(500)
-      ->content_like(qr/Exception=HASH/);
+      ->content_like(qr/Exception/);
 }
 
 # No error templates
@@ -87,7 +87,7 @@ BEGIN {
     $r->add("/exception_obj", sub { die bless {}, 'Exception'; });
     $t->request( GET '/exception_obj' )
       ->code_is(500)
-      ->content_like(qr/Exception=HASH/);
+      ->content_like(qr/Exception/);
 }
 
 # Deployment

--- a/t/response_error.t
+++ b/t/response_error.t
@@ -87,7 +87,7 @@ BEGIN {
     $r->add("/exception_obj", sub { die bless {}, 'Exception'; });
     $t->request( GET '/exception_obj' )
       ->code_is(500)
-      ->content_like(qr/500 - Internal Server Error/);
+      ->content_like(qr/500 - Exception=HASH/);
 }
 
 # Deployment
@@ -118,6 +118,7 @@ BEGIN {
 
 # StackTrace enabled
 {
+    local *STDERR;
     $ENV{KELP_CONFIG_DIR} = "$Bin/conf/stack_trace_enabled";
     my $app = Kelp->new( mode => 'test' );
     my $r   = $app->routes;


### PR DESCRIPTION
Hello Stefan, 
Hope finding you in good mood. (:

While adding more tests for deployment I found error in my previous solution. In deployment mode you get error string if you die "with a message"; but not "Internal Server Error" as it should. So I switched back to render_500 in Kelp.pm. 

Then I found that $self->render_error with stack_trace middleware enabled shows template not found exception stack_trace message, while it should not. So I moved <silence stack_trace> block to try block in $self->render_error.

And I've added some cosmetic changes if you die with exception.

I hope this changes will help for project (;